### PR TITLE
Added borrower id and borrower name on loan apply submission

### DIFF
--- a/apply_for_loan.php
+++ b/apply_for_loan.php
@@ -52,8 +52,9 @@
 
 
           <?php 
-
+           $name ="" ; $b_id = "";
             if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_POST['search'])) {
+             
                 $nid = $_POST['key'];
                 $br = $emp->findBorrower($nid);
                 if ($br) {
@@ -66,7 +67,7 @@
               }            
            ?>
 
-          <form action="" method="POST">
+          <form action="<?php echo $_SERVER['PHP_SELF'];?>" method="POST">
                 <div class="form-group row">
               <label for="inputBorrowerFirstName" class="text-right col-2 font-weight-bold col-form-label">Search brrower: </label>                      
               <div class="col-sm-6">
@@ -79,8 +80,25 @@
 
           </form>  
 
-          <form action="" method="post" enctype="multipart/form-data" name="myform" id="myform" />
+          <form action="<?php echo $_SERVER['PHP_SELF'];?>" method="post" enctype="multipart/form-data" name="myform" id="myform" >
             </div>
+<!--Added Borrower Name-->
+            <div class="form-group row">
+              <label for="borrower_name" class="text-right col-2 font-weight-bold col-form-label">Borrower Name</label>                      
+              <div class="col-sm-9">
+                  <input type="text"  name="borrower_name" class="form-control" value="<?php echo $name; ?>" readonly>
+              </div>
+            </div>
+
+            <!--Added Borrower ID-->
+            <div class="form-group row">
+              <label for="borrower_id" class="text-right col-2 font-weight-bold col-form-label">Borrower ID</label>                      
+              <div class="col-sm-9">
+                  <input type="text"  name="b_id" class="form-control" value="<?php echo $b_id; ?>" readonly>
+              </div>
+            </div>
+
+           
 
             <div class="form-group row">
               <label for="loanamount" class="text-right col-2 font-weight-bold col-form-label">Expected Loan amount</label>                      
@@ -106,7 +124,7 @@
              <div class="form-group row">
                 <label  class="text-right col-2 font-weight-bold col-form-label">Total amount including interest</label>                      
                  <div class="col-sm-9">
-                  <input type="text"  name="total_amount" class="form-control"readonly required>
+                  <input type="text"  name="total_amount" class="form-control" readonly required>
               </div>
             </div> 
 

--- a/assets/fpdf/fpdf.php
+++ b/assets/fpdf/fpdf.php
@@ -1028,8 +1028,8 @@ protected function _dochecks()
 	if(ini_get('mbstring.func_overload') & 2)
 		$this->Error('mbstring overloading must be disabled');
 	// Ensure runtime magic quotes are disabled
-	if(get_magic_quotes_runtime())
-		@set_magic_quotes_runtime(0);
+	//if(get_magic_quotes_runtime())
+	//	@set_magic_quotes_runtime(0);
 }
 
 protected function _checkoutput()

--- a/index.php
+++ b/index.php
@@ -132,7 +132,7 @@
 
                          $giveNotification = date('d-m-Y',strtotime('+3 months',strtotime($result['next_date'])));
 
-                           if ($curren_date > $giveNotification) {
+                         if (strtotime($curren_date) > strtotime($giveNotification)) {
 
                    ?> 
 


### PR DESCRIPTION
The Apply for Loan Form was giving an error that the b_id and the borrower name were invalid. This is because the Apply for Loan form was submitting the loan without the b_id and the borrower name while validation needed the b_id and the borrower name to process the loan application. I added the Borrower Id and the Borrower name in the Loan Form upon submission.